### PR TITLE
В реализации метода getHash, md5 заменен на fasthash

### DIFF
--- a/benchmar_test.go
+++ b/benchmar_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
+
+	"github.com/segmentio/fasthash/fnv1a"
 )
 
 const str = `00:03.869001-2998,CALL,2,process=rphost,p:processName=hrmcorp-n29,OSThread=8389,t:clientID=30190,t:applicationName=1CV8C,t:computerName=CA-TEST-RDP-1,t:connectID=331409,callWait=0,Usr=Парма,SessionID=533,Context=Система.ПолучитьИзВременногоХранилища,Interface=bc15bd01-10bf-413c-a856-ddc907fcd123,IName=IVResourceRemoteConnection,Method=0,CallID=25058,MName=send,Memory=-8208,MemoryPeak=589904,InBytes=0,OutBytes=0,CpuTime=1357 `
@@ -22,9 +24,21 @@ func BenchmarkGetHashWithRace(b *testing.B) {
 	}
 }
 
+func BenchmarkGetFastHashWithRace(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		getFastHashWitRace(str)
+	}
+}
+
 func BenchmarkGetHashWithoutRace(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		getHashWithoutRace(str)
+	}
+}
+
+func BenchmarkGetFastHashWithoutRace(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		getFastHashWithoutRace(str)
 	}
 }
 
@@ -81,6 +95,28 @@ func getHashWitRace(inStr string) string {
 func getHashWitWorkers(s string) string {
 
 	Sum := md5.Sum([]byte(s))
+	return fmt.Sprintf("%x", Sum)
+}
+
+func getFastHashWitRace(inStr string) string {
+	out := make(chan string)
+	// race pattern
+	sumString := func() {
+		Sum := fnv1a.HashString64(inStr)
+		out <- fmt.Sprintf("%x", Sum)
+	}
+
+	// работа на опережедние
+	go sumString()
+	go sumString()
+	go sumString()
+
+	return <-out
+}
+
+func getFastHashWithoutRace(s string) string {
+	Sum := fnv1a.HashString64(s)
+
 	return fmt.Sprintf("%x", Sum)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,15 +3,18 @@ module LogViewer
 go 1.14
 
 require (
+	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
+	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
 	github.com/atotto/clipboard v0.1.2
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gdamore/tcell v1.3.1-0.20200825151011-0c473b86d82f
-	github.com/go-echarts/go-echarts v1.0.0 // indirect
-	github.com/golangci/golangci-lint v1.29.0 // indirect
+	github.com/golang/mock v1.6.0
+	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
-	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/rivo/tview v0.0.0-20200712113419-c65badfc3d92
-	golang.org/x/sys v0.0.0-20200917073148-efd3b9a0ff20 // indirect
-	golang.org/x/text v0.3.3 // indirect
-	golang.org/x/tools v0.0.0-20200818005847-188abfa75333
+	github.com/segmentio/fasthash v1.0.3 // indirect
+	github.com/stretchr/testify v1.6.1
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
+	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 )

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"context"
-	"crypto/md5"
 	"encoding/csv"
 	"fmt"
 	"math"
@@ -19,6 +18,7 @@ import (
 	"github.com/atotto/clipboard"
 	"github.com/gdamore/tcell"
 	"github.com/rivo/tview"
+	"github.com/segmentio/fasthash/fnv1a"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 	// _ "net/http/pprof"
 )
@@ -568,7 +568,9 @@ func (tv *tableView) showmodal(str string) {
 }
 
 func getHash(inStr string) string {
-	Sum := md5.Sum([]byte(inStr))
+	//Sum := md5.Sum([]byte(inStr))
+	//return fmt.Sprintf("%x", Sum)
+	Sum := fnv1a.HashString64(inStr)
 	return fmt.Sprintf("%x", Sum)
 }
 


### PR DESCRIPTION
В реализации метода getHash md5 заменен на fasthash